### PR TITLE
Bug/test config error

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -5,6 +5,7 @@ development:
   local: false
 
 test:
+  local: true
 
 production:
   password: "xxx"

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -5,7 +5,7 @@ development:
   local: false
 
 test:
-  local: true
+  local: false
 
 production:
   password: "xxx"

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -5,7 +5,7 @@ development:
   local: false
 
 test:
-  local: false
+  local: true
 
 production:
   password: "xxx"


### PR DESCRIPTION
This fix makes bundle exec rake pass all tests on new installs. The failing test used to be this:

[4/6] ExceptionsTest#test_GET_/sets/show/# = 0.10 s    
  1) Error:
ExceptionsTest#test_GET_/sets/show/#:
ActionView::Template::Error: undefined method `[]' for nil:NilClass
    /home/[path]/spectral-workbench/app/views/sets/show.html.erb:108:in `_app_views_sets_show_html_erb__548404879__574367738'

Putting this in config/config.yml.example as well as config/config.yml will make it so new installs won't see this error.

test:
  local: true
