### PR TITLE
Add index to tag_id field in snapshots table to help performance.

### DIFF
--- a/db/migrate/20160421084510_add_index_to_snapshots.rb
+++ b/db/migrate/20160421084510_add_index_to_snapshots.rb
@@ -1,0 +1,5 @@
+class AddIndexToSnapshots < ActiveRecord::Migration
+  def change
+    add_index :snapshots, :tag_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20151202002150) do
+ActiveRecord::Schema.define(:version => 20160421084510) do
 
   create_table "comments", :force => true do |t|
     t.string   "author"
@@ -673,6 +673,8 @@ ActiveRecord::Schema.define(:version => 20151202002150) do
     t.datetime "created_at",  :null => false
     t.datetime "updated_at",  :null => false
   end
+
+  add_index "snapshots", ["tag_id"], :name => "index_snapshots_on_tag_id"
 
   create_table "spectra_sets", :force => true do |t|
     t.string   "title",      :default => "", :null => false


### PR DESCRIPTION
This small patch was pushed to production this morning.