### PR TITLE
Update spectrums_controller.rb

### DIFF
--- a/app/controllers/spectrums_controller.rb
+++ b/app/controllers/spectrums_controller.rb
@@ -167,11 +167,11 @@ class SpectrumsController < ApplicationController
 
   def search
     params[:id] = params[:q].to_s if params[:id].nil?
-    @spectrums = Spectrum.where('title LIKE ?',params[:id]+"%").order("id DESC").paginate(:page => params[:page], :per_page => 24)
+    @spectrums = Spectrum.where('title LIKE ? OR author LIKE ?',"%#{params[:id]}%", "%#{params[:id]}%").paginate(:page => params[:page], :per_page => 24)
     if params[:capture]
       render :partial => "capture/results", :layout => false
     else
-      @sets = SpectraSet.where('title LIKE ? OR notes LIKE ?',"%"+params[:id]+"%", "%"+params[:id]+"%").order("id DESC").paginate(:page => params[:set_page])
+      @sets = SpectraSet.where('title LIKE ? OR author LIKE ?',"%#{params[:id]}%", "%#{params[:id]}%").order("id DESC").paginate(:page => params[:set_page])
     end
   end
 

--- a/app/controllers/spectrums_controller.rb
+++ b/app/controllers/spectrums_controller.rb
@@ -167,7 +167,7 @@ class SpectrumsController < ApplicationController
 
   def search
     params[:id] = params[:q].to_s if params[:id].nil?
-    @spectrums = Spectrum.where('title LIKE ? OR author LIKE ?',"%#{params[:id]}%", "%#{params[:id]}%").paginate(:page => params[:page], :per_page => 24)
+    @spectrums = Spectrum.where('title LIKE ? OR author LIKE ?',"%#{params[:id]}%", "%#{params[:id]}%").order("id DESC").paginate(:page => params[:page], :per_page => 24)
     if params[:capture]
       render :partial => "capture/results", :layout => false
     else

--- a/test/functional/spectrums_controller_test.rb
+++ b/test/functional/spectrums_controller_test.rb
@@ -142,6 +142,17 @@ class SpectrumsControllerTest < ActionController::TestCase
     assert_not_nil :sets
   end
 
+  test "should show search results for similarities with author name and spectrum title" do
+    get :search, :id => spectrums(:one).title
+    assert_response :success
+    assert_not_nil :spectrums
+    assert_not_nil :sets
+    get :search, :id => spectrums(:one).author
+    assert_response :success
+    assert_not_nil :spectrums
+    assert_not_nil :sets
+  end
+  
   test "should respond to choose" do
     session[:user_id] = User.first.id # log in
     get :choose, :id => 'calibration'


### PR DESCRIPTION
Fixes #476.

Now, when searching for spectra, queries that are similar to a spectra author's name will display said spectra.

Here is an example down below:
![spectral-author-search](https://user-images.githubusercontent.com/52892257/72188141-e16b4b80-33f9-11ea-9376-acef5aae7b83.png)

What do you think @publiclab/reviewers?

