### PR TITLE
Allow greater set naming flexibility

### DIFF
--- a/app/controllers/sets_controller.rb
+++ b/app/controllers/sets_controller.rb
@@ -92,7 +92,9 @@ class SetsController < ApplicationController
       @set.spectrums << spectra
       redirect_to "/sets/"+@set.id.to_s
     else
-      flash[:error] = "Failed to save set."
+      @set.errors.full_messages.each do |err|
+        flash[:error] = err 
+      end
       render :action => "new", :id => params[:id]
     end
   end

--- a/app/models/spectra_set.rb
+++ b/app/models/spectra_set.rb
@@ -8,7 +8,7 @@ class SpectraSet < ActiveRecord::Base
   has_and_belongs_to_many :spectrums
   belongs_to :user
 
-  validates :title, :format => { with: /\A[\w\ -\'\"]+\z/, message: "can contain only letters, numbers, and spaces." }
+  validates :title, :format => { with: /\A[\w\ -\@"^\[\]]+\z/, message: "can contain only letters, numbers, and spaces." }
 
   def calibrated_spectrums
     self.spectrums.where(calibrated: true).uniq

--- a/test/unit/spectra_set_test.rb
+++ b/test/unit/spectra_set_test.rb
@@ -78,4 +78,11 @@ class SpectraSetTest < ActiveSupport::TestCase
     assert_not_nil set.snapshots(false)
   end
 
+  test "json parsable with title" do
+    set = SpectraSet.last
+    set.title = "./!@$%^&*)_+-=HEllo123`~?<>{}[]#,,.\""
+    json = set.to_json
+    parsed = JSON.parse(json).with_indifferent_access
+    assert parsed[:title].eql? "./!@$%^&*)_+-=HEllo123`~?<>{}[]#,,.\""
+  end
 end


### PR DESCRIPTION
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!
Closes #350 

app/controllers/sets_controller.rb: Reports validation errors
app/models/spectra_set.rb: Allows greater naming flexibility for set title
test/unit/spectra_set_test.rb: Added unit test to make sure the hash can be made into JSON and back, retaining the information.

* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Thanks!
