### PR TITLE
Adding action for new interface for fetching recent calibration

### DIFF
--- a/test/controllers/capture_controller_test.rb
+++ b/test/controllers/capture_controller_test.rb
@@ -18,6 +18,16 @@ class CaptureControllerTest < ActionController::TestCase
     assert_not_nil :spectrums
   end
 
+  test 'should get capture while not logged in' do
+    get :index
+    assert_response :success
+  end
+
+  test 'should get capture/v2 while not logged in' do
+    get :index2
+    assert_response :success
+  end
+
   test 'should get capture while logged in' do
     session[:user_id] = users(:quentin).id # log in
     get :index


### PR DESCRIPTION
Restored ability for the new interface to work without login for features like capturing spectral data, fetching recent calibrations and switching for new calibrations. 

* [x] tests pass -- `rake test`
* [x] reviewed/confirmed/tested by another contributor or maintainer

