### PR TITLE
Restoring missing routes and actions

### DIFF
--- a/app/views/spectrums/edit.html.erb
+++ b/app/views/spectrums/edit.html.erb
@@ -39,7 +39,7 @@
     <input class="btn-primary btn" type="submit" value="Submit" />
     <% if current_user.role == 'admin' %>
       <%= link_to '<i class="fa fa-trash"></i> Delete'.html_safe, { :action => "destroy", :id => @spectrum.id },
-         :confirm => "Are you sure?", :method => :delete, :class => "btn btn-medium" %>
+         data: { confirm: 'Are you sure?' }, :method => :delete, :class => "btn btn-medium" %>
     <% end %>
     &nbsp; <%= link_to 'Back', spectrums_path %>
   </p>

--- a/app/views/spectrums/show2.html.erb
+++ b/app/views/spectrums/show2.html.erb
@@ -57,7 +57,7 @@
               <div class="btn-group">
                 <a class="btn btn-small" href="/spectrums/<%= @spectrum.id %>/edit"><i class="fa fa-pencil"></i></a>
                 <% if @spectrum.is_deletable? %>
-                  <%= link_to '<i class="fa fa-trash"></i>'.html_safe, "/spectrums/destroy/#{@spectrum.id}", :confirm => 'Are you sure?', :class => "btn btn-small" %>
+                  <%= link_to '<i class="fa fa-trash"></i>'.html_safe, "/spectrums/destroy/#{@spectrum.id}", data: { confirm: 'Are you sure?' }, :class => "btn btn-small" %>
                 <% else %>
                   <a rel="tooltip" title="You cannot delete this because other spectra rely upon its data. Remove these dependencies and this will be enabled." class="btn btn-small disabled"><i class="fa fa-trash"></i></a>
                 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ SpectralWorkbench::Application.routes.draw do
   get '/spectrums/destroy/:id' => 'spectrums#destroy' 
   get '/spectrums/:id/edit' => 'spectrums#edit'
   post '/spectrums/:id/update' => 'spectrums#update'
+  post '/spectrums/fork/:id' => 'spectrums#fork'
+  post '/spectrums/choose/:id' => 'spectrums#choose'
 
   post '/comments/spectrum/:id' => 'comments#spectrum'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,10 @@ SpectralWorkbench::Application.routes.draw do
 
   get '/upload' => 'spectrums#new'
   post '/spectrums/create' => 'spectrums#create'
+  get '/spectrums/destroy/:id' => 'spectrums#destroy' 
+  get '/spectrums/:id/edit' => 'spectrums#edit'
+  post '/spectrums/:id/update' => 'spectrums#update'
+
   post '/comments/spectrum/:id' => 'comments#spectrum'
 
   get '/tags/change_reference/:id' => 'tags#change_reference'


### PR DESCRIPTION
The following routes/functionalities are not present on the app and result in a `404 - not found` error: 

Editing and updating the spectrum - 
**Routes responsible:**
```ruby
/capture/edit
/capture/update
```

Deleting the spectrum with confirmation prompt - 
**Routes responsible:**
```ruby
/spectrums/destroy/{spectrum_id}
```

Though I've tried to restore the edit and update functionality but it is still seems to be non-functional. 
The destroy functionality on the other hand has been restored with the confirmation prompt.
 
* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Thanks!
