### PR TITLE
Added tests for editing spectrum title and notes

### DIFF
--- a/app/controllers/spectrums_controller.rb
+++ b/app/controllers/spectrums_controller.rb
@@ -351,7 +351,7 @@ class SpectrumsController < ApplicationController
 
     @spectrum.title = params[:spectrum][:title] unless params[:spectrum].nil? || params[:spectrum][:title].nil?
     @spectrum.notes = params[:spectrum][:notes] unless params[:spectrum].nil? || params[:spectrum][:notes].nil?
-    @spectrum.data  = params[:spectrum][:data] unless  params[:spectrum].nil? || params[:data].nil?
+    @spectrum.data  = params[:spectrum][:data] unless  params[:spectrum].nil? || params[:spectrum][:data].nil?
 
     # clean this up
     respond_to do |format|

--- a/app/controllers/spectrums_controller.rb
+++ b/app/controllers/spectrums_controller.rb
@@ -349,9 +349,9 @@ class SpectrumsController < ApplicationController
     @spectrum = Spectrum.find(params[:id])
     require_ownership(@spectrum)
 
-    @spectrum.title = params[:title] unless params[:title].nil?
-    @spectrum.notes = params[:notes] unless params[:notes].nil?
-    @spectrum.data  = params[:data] unless params[:data].nil?
+    @spectrum.title = params[:spectrum][:title] unless params[:spectrum].nil? || params[:spectrum][:title].nil?
+    @spectrum.notes = params[:spectrum][:notes] unless params[:spectrum].nil? || params[:spectrum][:notes].nil?
+    @spectrum.data  = params[:spectrum][:data] unless  params[:spectrum].nil? || params[:data].nil?
 
     # clean this up
     respond_to do |format|

--- a/test/controllers/spectrums_controller_test.rb
+++ b/test/controllers/spectrums_controller_test.rb
@@ -250,7 +250,7 @@ class SpectrumsControllerTest < ActionController::TestCase
     assert_response :redirect
     # to check if the new spectrum title was updated
     assert_equal 'Spectrum was successfully updated.', flash[:notice]
-    assert_equal "Really cool spectrum" , Spectrum.find(spectrums(:one)).title
+    assert_equal "Really cool spectrum" , Spectrum.find(spectrums(:one).id).title
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end
@@ -262,7 +262,7 @@ class SpectrumsControllerTest < ActionController::TestCase
     assert_response :redirect
     # to check if the new spectrum notes was updated
     assert_equal 'Spectrum was successfully updated.', flash[:notice]
-    assert_equal "Neon spectrum info", Spectrum.find(spectrums(:one)).notes
+    assert_equal "Neon spectrum info", Spectrum.find(spectrums(:one).id).notes
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end

--- a/test/controllers/spectrums_controller_test.rb
+++ b/test/controllers/spectrums_controller_test.rb
@@ -249,8 +249,8 @@ class SpectrumsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     # to check if the new spectrum title was updated
-    assert_equal flash[:success], 'Spectrum was successfully updated.'
-    assert_equal "Really cool spectrum" , spectrums(:one).title
+    assert_equal 'Spectrum was successfully updated.', flash[:success]
+    assert_equal "Really cool spectrum" , Spectrum.find(spectrums(:one)).title
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end
@@ -262,8 +262,8 @@ class SpectrumsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     # to check if the new spectrum notes was updated
-    assert_equal flash[:success], 'Spectrum was successfully updated.'
-    assert_equal "Neon spectrum info", spectrums(:one).notes
+    assert_equal 'Spectrum was successfully updated.', flash[:success]
+    assert_equal "Neon spectrum info", Spectrum.find(spectrums(:one)).notes
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end

--- a/test/controllers/spectrums_controller_test.rb
+++ b/test/controllers/spectrums_controller_test.rb
@@ -243,6 +243,29 @@ class SpectrumsControllerTest < ActionController::TestCase
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end
 
+  test 'should update spectrum title' do
+    session[:user_id] = User.first.id # log in
+    patch :update, params: { id: spectrums(:one).id, spectrum: { title: "Really cool spectrum" } }
+
+    assert_response :redirect
+    # to check if the new spectrum title was updated
+    assert_equal "Really cool spectrum" , spectrums(:one).title
+    assert_not_nil :spectrum
+    assert_redirected_to spectrum_path(assigns(:spectrum))
+  end
+
+
+  test 'should update spectrum notes' do
+    session[:user_id] = User.first.id # log in
+    patch :update, params: { id: spectrums(:one).id, spectrum: { notes: "Neon spectrum info." } }
+
+    assert_response :redirect
+    # to check if the new spectrum notes was updated
+    assert_equal "Neon spectrum info", spectrums(:one).notes
+    assert_not_nil :spectrum
+    assert_redirected_to spectrum_path(assigns(:spectrum))
+  end
+
   test 'should calibrate spectrum' do
     session[:user_id] = User.first.id # log in
     # we need a real spectrum with an image to work with:

--- a/test/controllers/spectrums_controller_test.rb
+++ b/test/controllers/spectrums_controller_test.rb
@@ -249,6 +249,7 @@ class SpectrumsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     # to check if the new spectrum title was updated
+    assert_equal flash[:success], 'Spectrum was successfully updated.'
     assert_equal "Really cool spectrum" , spectrums(:one).title
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
@@ -261,6 +262,7 @@ class SpectrumsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     # to check if the new spectrum notes was updated
+    assert_equal flash[:success], 'Spectrum was successfully updated.'
     assert_equal "Neon spectrum info", spectrums(:one).notes
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))

--- a/test/controllers/spectrums_controller_test.rb
+++ b/test/controllers/spectrums_controller_test.rb
@@ -249,12 +249,11 @@ class SpectrumsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     # to check if the new spectrum title was updated
-    assert_equal 'Spectrum was successfully updated.', flash[:success]
+    assert_equal 'Spectrum was successfully updated.', flash[:notice]
     assert_equal "Really cool spectrum" , Spectrum.find(spectrums(:one)).title
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end
-
 
   test 'should update spectrum notes' do
     session[:user_id] = User.first.id # log in
@@ -262,7 +261,7 @@ class SpectrumsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     # to check if the new spectrum notes was updated
-    assert_equal 'Spectrum was successfully updated.', flash[:success]
+    assert_equal 'Spectrum was successfully updated.', flash[:notice]
     assert_equal "Neon spectrum info", Spectrum.find(spectrums(:one)).notes
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))

--- a/test/controllers/spectrums_controller_test.rb
+++ b/test/controllers/spectrums_controller_test.rb
@@ -262,7 +262,7 @@ class SpectrumsControllerTest < ActionController::TestCase
     assert_response :redirect
     # to check if the new spectrum notes was updated
     assert_equal 'Spectrum was successfully updated.', flash[:notice]
-    assert_equal "Neon spectrum info", Spectrum.find(spectrums(:one).id).notes
+    assert_equal "Neon spectrum info.", Spectrum.find(spectrums(:one).id).notes
     assert_not_nil :spectrum
     assert_redirected_to spectrum_path(assigns(:spectrum))
   end


### PR DESCRIPTION
#699 referenced the missing routes for the edit and update spectrum. Once that is fixed, these tests will secure the functionality for editing and updating the spectrum title and notes.

<img width="863" alt="Screenshot 2021-08-16 at 6 24 13 PM" src="https://user-images.githubusercontent.com/58583793/129588991-1c1d62c9-7f99-401d-a7c1-c10106260c5a.png">


* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Thanks!
