### PR TITLE
Improving accessibility on the new interface at /v2

### DIFF
--- a/app/assets/javascripts/new-interface.js
+++ b/app/assets/javascripts/new-interface.js
@@ -7,7 +7,8 @@
 */
 function homePage() {
   if ($("#landing-page-content").hide()) {
-      $('html').css('background', '#ffffff');
+      $("html, .full-strecth-block").css('background', '#f5f5f5');
+      $('.bs-stepper .step-trigger').css('color', '#272727');
       $("#landing-page-content").show();
 
       $("div#capture-page-content").hide();
@@ -18,7 +19,7 @@ function homePage() {
 
 function settingsPage() {
   $('html').css('background', '#272727');
-
+  $('.bs-stepper .step-trigger').css('color', '#f5f5f5');
   $("#heightIndicator").removeClass("capture-settings-hide");
   $("#heightIndicator").show();
   $("#webcam").css('pointer-events', '');
@@ -48,6 +49,7 @@ function settingsPage() {
 
 function capturePage() {
   $("html, .full-strecth-block").css('background', '#272727');
+  $('.bs-stepper .step-trigger').css('color', '#f5f5f5');
   $("#landing-page-content").hide();
   $("#capture-option").addClass("capture-settings-hide");
   $("#heightIndicator").addClass("capture-settings-hide");
@@ -71,6 +73,7 @@ function capturePage() {
 
 function savePage() {
   $("html, .full-strecth-block").css('background', '#272727');
+  $('.bs-stepper .step-trigger').css('color', '#f5f5f5');
   $W.saveSpectrum();
   $("#landing-page-content").hide();
   $("div#capture-page-content").hide();
@@ -82,7 +85,8 @@ function savePage() {
 
 
 $(document).ready(function () {
-  $('html').css('background', '#ffffff');
+  $("html, .full-strecth-block").css('background', '#ffffff');
+  $('.bs-stepper .step-trigger').css('color', '#272727');
 
   $("div#capture-page-content").hide();
   $("div#capture-settings").hide();

--- a/app/views/capture/_newsave.html.erb
+++ b/app/views/capture/_newsave.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <div class="span9">
-<img style="display:none;background:#333;" id="spectrum-preview" />
+<img style="display:none;background:#333;" id="spectrum-preview" alt="Spectrum image preview" />
 
 <h3 style="margin-bottom:6px;">Save this spectrum
 <% if logged_in? %>
@@ -62,7 +62,7 @@
   <input name="lon" type="hidden" id="lon" />
   <% if logged_in? %>
   <p><small>Choose a recent reference calibration, or use this as a new calibration.</small></p>
-  <select name="spectrum[calibration_id]" id="calibration_id">
+  <select aria-label="Current calibration" name="spectrum[calibration_id]" id="calibration_id">
     <%= render partial: 'capture/calibrations', locals: { calibrations: @calibrations, calibration: @calibration } %>
   </select>
   <% end %>

--- a/app/views/capture/index2.html.erb
+++ b/app/views/capture/index2.html.erb
@@ -1,4 +1,5 @@
-<script src="https://cdn.temasys.io/adapterjs/0.15.x/adapter.min.js"></script>
+<html lang="en" role="main">
+<%= javascript_include_tag "adapterjs/publish/adapter.min.js" %> 
 <%= javascript_include_tag "spectral-workbench/examples/capture/capture.js" %> 
 <%= javascript_include_tag "spectral-workbench/dist/capture.dist.js" %> 
 <%= javascript_include_tag "new-interface" %>
@@ -38,10 +39,10 @@
 
 <nav class="navbar navbar-inverse capture-navbar">
   <div class="navbar-inner">
-  <a class="brand" href="/"><img style="padding:-2px;width:20px;" src="/images/logo.png" /></a>
+  <a class="brand" href="/"><img style="padding:-2px;width:20px;" src="/images/logo.png" alt="Spectral Workbench logo" /></a>
     <div class="pull-right">
       <% unless logged_in? %><a onClick="$('#loginmodal').modal('show');" class="btn">Log in</a><% end %>
-      <a class="btn btn-inverse" href="http://publiclab.org/spectral-workbench"><i class="fa fa-white fa-question-circle"></i></a>
+      <a class="btn btn-inverse" href="http://publiclab.org/spectral-workbench" aria-label="Click here to know more about spectral workbench"><i class="fa fa-white fa-question-circle"></i></a>
     </div>
     <% if logged_in? %><p id="login-status">(logged in as <%=h current_user.login %>)<p><% end %>
     <p class="capture-messages" style="float:left;"></p>
@@ -53,28 +54,28 @@
   
     <div class="full-strecth-block bs-stepper">
   
-      <div id="testnav" class="bs-stepper-header" role="tablist" style="z-index:100;">
+      <div id="testnav" class="bs-stepper-header" role="tablist" style="z-index:150;" role="navigation">
         <%# <!-- your steps here --> %>
         <div class="step" data-target="#landing-page">
-          <button type="button" class="step-trigger" role="tab" aria-controls="landing-page" id="homebtn" onclick="homePage()">
+          <button type="button" class="step-trigger" role="tab" id="homebtn" onclick="homePage()">
             <span class="bs-stepper-label">Home Page</span>
           </button>
         </div>
         <div class="line"></div>
         <div class="step" data-target="#settings">
-          <button type="button" class="step-trigger" role="tab" aria-controls="setting" id="settingsbtn" onclick="settingsPage()">
+          <button type="button" class="step-trigger" role="tab" id="settingsbtn" onclick="settingsPage()">
             <span class="bs-stepper-label">Settings</span>
           </button>
         </div>
         <div class="line"></div>
         <div class="step" data-target="#capture">
-          <button type="button" class="step-trigger" role="tab" aria-controls="capture" id="capturebtn" onclick="capturePage()">
+          <button type="button" class="step-trigger" role="tab" id="capturebtn" onclick="capturePage()">
             <span class="bs-stepper-label">Capture</span>   
           </button>
         </div>
         <div class="line"></div>
         <div class="step" data-target="#save">
-          <button type="button" class="step-trigger" role="tab" aria-controls="save" id="savebtn" onclick="savePage()">
+          <button type="button" class="step-trigger" role="tab" id="savebtn" onclick="savePage()">
             <span class="bs-stepper-label">Save</span>
           </button>
         </div>
@@ -85,7 +86,7 @@
     <div id="landing-page-content">
     <h1> 
       <div style="padding-bottom:1rem">
-        <img src="/images/logo.png">
+        <img src="/images/logo.png" alt="Spectral Workbench logo">
       </div>
       Spectral WorkBench <div><small>by Public Lab</small></div>
     </h1>
@@ -99,10 +100,10 @@
             <button class="demo-button next" id="landing-page-next">Capture Spectra</button>
             <br><br><br>
             <span>
-              <a href="https://spectralworkbench.org/dashboard"><i class="fa fa-home"></i></a>
-              <a href="https://github.com/publiclab/spectral-workbench.js"><i class="fa fa-github"></i></a>
-              <a href="https://twitter.com/intent/follow?original_referer=https%3A%2F%2Fspectralworkbench.org%2Fdashboard&ref_src=twsrc%5Etfw&screen_name=SpectralWB&tw_p=followbutton"><i class="fa fa-twitter"></i></a>
-              <a href="https://publiclab.org/wiki/spectral-workbench-help"><i class="fa fa-info-circle"></i></a>
+              <a href="https://spectralworkbench.org/dashboard" aria-label="Go to home"><i class="fa fa-home"></i></a>
+              <a href="https://github.com/publiclab/spectral-workbench.js" aria-label="Checkout the spectral workbench library on github"><i class="fa fa-github"></i></a>
+              <a href="https://twitter.com/intent/follow?original_referer=https%3A%2F%2Fspectralworkbench.org%2Fdashboard&ref_src=twsrc%5Etfw&screen_name=SpectralWB&tw_p=followbutton" aria-label="Follow spectral workbench on twitter"><i class="fa fa-twitter"></i></a>
+              <a href="https://publiclab.org/wiki/spectral-workbench-help" aria-label="Click here in case of help regarding spectral workbench"><i class="fa fa-info-circle"></i></a>
             </span>
     </div>
 
@@ -122,11 +123,11 @@
             <div id="spectrum-ex" style="padding-bottom:0px;padding-top:0.5rem;">
               <div class="spectrum-example-vertical" style="display:none;">
                 <p style="margin-top:4px;">Point your spectrometer at a light and click on the video above to choose a cross-section to sample. (<a href="http://publiclab.org/wiki/spectral-workbench-usage">Learn more &raquo;</a>)</p>
-                <img src="/images/example-cfl-vertical.png" style="height:136px; padding-bottom:1rem" id="cfl-resp"/>
+                <img src="/images/example-cfl-vertical.png" style="height:136px; padding-bottom:1rem" id="cfl-resp" alt="vertical spectrum example image" />
               </div>
               <div class="spectrum-example-horizontal">
                 <p style="margin-top:4px;">Point your spectrometer at a light and click on the video above to choose a cross-section as shown below. (<a href="http://publiclab.org/wiki/spectral-workbench-usage">Learn more &raquo;</a>)</p>
-                <img class="img-rot" width="480px" src="/images/calibration-example.png" />
+                <img class="img-rot" width="480px" src="/images/calibration-example.png" alt="horizontal spectrum example image" />
               </div>
             </div>
   
@@ -175,7 +176,7 @@
 
                 <div>
                 <p>Using calibration:</p>
-                <select name="spectrum[calibration_id]" class="select-calibration select-calibration-capture span2">
+                <select aria-label="Current calibration" name="spectrum[calibration_id]" class="select-calibration select-calibration-capture span2">
                   <%= render partial: 'capture/calibrations', locals: { calibrations: @calibrations, calibration: @calibration } %>
                 </select>
                 <a class="btn btn-inverse btn-switch-calibration-capture">Switch calibration</a>
@@ -231,7 +232,7 @@
 
               <div class="responsive-cal" style="padding-top: 20px;">
                 <p><small>Using calibration:</small></p>
-                <select name="spectrum[calibration_id]" class="select-calibration select-calibration-capture span2">
+                <select aria-label="Current calibration" name="spectrum[calibration_id]" class="select-calibration select-calibration-capture span2">
                   <%= render partial: 'capture/calibrations', locals: { calibrations: @calibrations, calibration: @calibration } %>
                 </select>
                 <a class="btn btn-inverse btn-switch-calibration-capture">Switch calibration</a>
@@ -276,3 +277,4 @@
       })();
     </script>
 </body>
+</html>


### PR DESCRIPTION
Fixed contrast issues and added relevant aria-labels and alt tags following WCAG guidelines 

Following is the result after the implementation 

  
![accessibility](https://user-images.githubusercontent.com/58583793/129589660-2c01ac9c-69ec-4527-a8e7-716161cb7ea8.jpeg)

- The remaining colour contrast issues at `Capture` tab for instance are due to overlapping elements (like the flot js graph) which are non-identifiable by the [_Axe Web Accessibility tool_](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) hence shouldn't be a problem. 
- Rest of the issues direct associating captions on the `vid` element, which are irrelevant, since here there is no need for captions


Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Thanks!
