### PR TITLE
Using `adapterjs` from modules instead of CDN link

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "ace-builds": "jywarren/ace-builds#v1.2.4",
+    "adapterjs": "^0.15.5",
     "bootstrap-css": "jozefizso/bower-bootstrap-css#~2.3.2",
     "bs-stepper": "^1.7.0",
     "d3": "^3.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,11 @@ ace-builds@jywarren/ace-builds#v1.2.4:
   version "1.2.3"
   resolved "https://codeload.github.com/jywarren/ace-builds/tar.gz/48e1f6e7951f0bf6c200853f33ae468ed4a38fca"
 
+adapterjs@^0.15.5:
+  version "0.15.5"
+  resolved "https://registry.yarnpkg.com/adapterjs/-/adapterjs-0.15.5.tgz#48ece82a6f4995f410373cf53a43954fceed2ef7"
+  integrity sha512-DbeQ8QXx7oUR2JcXrrTF47+F4BeVQUHgxSntpalp9fdKmp/02lxcpTPEF417ZOh5gqqCB320y20znzata2LiMw==
+
 ajv@^6.12.3:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"


### PR DESCRIPTION
https://yarnpkg.com/package/adapterjs 
Using adapterjs dependency from lib instead of the CDN link


* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Thanks!
