### PR TITLE
 Added routes test for sets/create/:id

### DIFF
--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -4,6 +4,9 @@ require 'test_helper'
 
 class RoutesTest < ActionDispatch::IntegrationTest
   fixtures :all
+ test "test get request for sets create" do
+ assert_routing({ path: '/sets/create/:id', method: 'post' }, {controller: 'sets', action: 'create', id: ':id' })
+ end
 
   test "test spectrums choose route" do
     assert_routing({ path: '/spectrums/choose', method: :post }, { controller: 'spectrums', action: 'choose' })


### PR DESCRIPTION
Related to issue #743, https://github.com/publiclab/spectral-workbench/issues/743#issue-1019666391
Added routes test for sets/create/:id
Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer