### PR TITLE
Add routes test for spectrums/embed2/:id

### DIFF
--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -16,4 +16,8 @@ class RoutesTest < ActionDispatch::IntegrationTest
   test "test spectrums choose route" do
     assert_routing({ path: '/spectrums/choose', method: :post }, { controller: 'spectrums', action: 'choose' })
   end
+
+  test "test get request for spectrums embed2" do
+    assert_routing({ path: '/spectrums/embed2/:id', method: 'get' }, {controller: 'spectrums', action: 'embed2', id: ':id' })
+  end    
 end


### PR DESCRIPTION
Fixes #760

Add routes test for spectrums/embed2/:id. Update the file routes_test.rb in the spectral-workbench repository 
```
  test "test get request for spectrums embed2" do
    assert_routing({ path: '/spectrums/embed2/:id', method: 'get' }, {controller: 'spectrums', action: 'embed2', id: ':id' })
  end    
```


