### PR TITLE
Add routes test for spectrums/embed/:id #759

### DIFF
--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -16,4 +16,9 @@ class RoutesTest < ActionDispatch::IntegrationTest
   test "test spectrums choose route" do
     assert_routing({ path: '/spectrums/choose', method: :post }, { controller: 'spectrums', action: 'choose' })
   end
+  
+  test "test get request for spectrums embed" do
+    assert_routing({ path: '/spectrums/embed/:id', method: 'get' }, {controller: 'spectrums', action: 'embed', id: ':id' })
+  end
+
 end


### PR DESCRIPTION
Modified [#759](https://github.com/publiclab/spectral-workbench/issues/759)
Added routes test for spectrums/embed/:id in [routes_test.rb](https://github.com/publiclab/spectral-workbench/blob/main/test/integration/routes_test.rb)