### PR TITLE
Bump spectral-workbench.js to v0.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "leaflet": "^1.7.1",
     "moment": "~2.19.3",
     "nvd3": "~1.7.1",
-    "spectral-workbench": "^0.2.0"
+    "spectral-workbench": "^0.2.3"
   },
   "engines": {
     "yarn": ">= 1.0.0"


### PR DESCRIPTION
After https://github.com/publiclab/spectral-workbench.js/pull/290

will need `yarn install` run for lockfile change