### PR TITLE
Added edroutes test for spectrums/clone_search #860

### DIFF
--- a/test/integration/routes_test.rb
+++ b/test/integration/routes_test.rb
@@ -116,5 +116,9 @@ class RoutesTest < ActionDispatch::IntegrationTest
   test "test get request for spectrums anonymous" do
     assert_routing({ path: '/spectrums/anonymous', method: 'get' }, {controller: 'spectrums', action: 'show', id: 'anonymous'})
   end
+
+  test "test get request for spectrums clone_search" do
+    assert_routing({ path: '/spectrums/clone_search', method: 'get' }, {controller: 'spectrums', action: 'clone_search'})
+  end
   
 end


### PR DESCRIPTION
Added routes test for spectrums/clone_search in `routes_test.rb`

Fixes #860 

Make sure these boxes are checked before your pull request is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- `rake test`
* [ ] code is in uniquely-named feature branch, and has been rebased on top of latest master (especially if you've been asked to make additional changes)
* [ ] pull request are descriptively named
* [ ] if possible, multiple commits squashed if they're smaller changes
* [ ] reviewed/confirmed/tested by another contributor or maintainer

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/wiki/contributing-to-public-lab-software

Thanks!
